### PR TITLE
Exposed 8443 in docker-compose and fixed a typo on the dashboard

### DIFF
--- a/config/grafana/dashboard.json
+++ b/config/grafana/dashboard.json
@@ -221,7 +221,7 @@
       ],
       "datasource": "Prometheus",
       "decimals": 0,
-      "description": "The number fo all oauth tokens issued by all instances during the dashboard time.",
+      "description": "The number of all oauth tokens issued by all instances during the dashboard time.",
       "format": "none",
       "gauge": {
         "maxValue": 100,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - "6749:6749"
       - "4466:4466"
+      - "8443:8443"
     networks:
       demonetwork:
         aliases:


### PR DESCRIPTION
- Port 8443 used by the runtime service was not exposed by docker-compose.
- Typo in the dashboard fo -> of was fixed.